### PR TITLE
libwebrtc と合わせて使おうとした際にビルドエラーとなる箇所の修正

### DIFF
--- a/include/shiguredo/mp4/box.hpp
+++ b/include/shiguredo/mp4/box.hpp
@@ -43,7 +43,9 @@ class Box {
   void seekToEnd(std::istream& is);
   void setOffsetAndDataSize(const std::uint64_t, const std::uint64_t);
 
+#if __cplusplus >= 202002L
   auto operator<=>(const Box&) const = default;
+#endif
 
  protected:
   BoxType m_type;
@@ -67,7 +69,9 @@ class FullBox : public Box {
   std::uint64_t readVersionAndFlag(bitio::Reader*);
   std::uint64_t getDataSize() const override;
 
+#if __cplusplus >= 202002L
   auto operator<=>(const FullBox&) const = default;
+#endif
 
  protected:
   std::uint8_t m_version = 0;
@@ -79,7 +83,9 @@ class AnyTypeBox : public Box {
   void setType(const BoxType&);
   BoxType getType() const;
 
+#if __cplusplus >= 202002L
   auto operator<=>(const AnyTypeBox&) const = default;
+#endif
 };
 
 }  // namespace shiguredo::mp4

--- a/include/shiguredo/mp4/box/co64.hpp
+++ b/include/shiguredo/mp4/box/co64.hpp
@@ -29,7 +29,9 @@ class Co64 : public FullBox {
   std::uint64_t readData(std::istream& is) override;
   std::uint64_t getDataSize() const override;
 
+#if __cplusplus >= 202002L
   auto operator<=>(const Co64&) const = default;
+#endif
 
  private:
   std::vector<std::uint64_t> m_chunk_offsets;

--- a/include/shiguredo/mp4/box/stco.hpp
+++ b/include/shiguredo/mp4/box/stco.hpp
@@ -29,7 +29,9 @@ class Stco : public FullBox {
   std::uint64_t readData(std::istream&) override;
   std::uint64_t getDataSize() const override;
 
+#if __cplusplus >= 202002L
   auto operator<=>(const Stco&) const = default;
+#endif
 
  private:
   std::vector<std::uint32_t> m_chunk_offsets;

--- a/include/shiguredo/mp4/box/stsc.hpp
+++ b/include/shiguredo/mp4/box/stsc.hpp
@@ -32,7 +32,9 @@ class StscEntry {
 
   std::uint64_t writeData(bitio::Writer*) const;
   std::uint64_t readData(bitio::Reader*);
+#if __cplusplus >= 202002L
   auto operator<=>(const StscEntry&) const = default;
+#endif
 
  private:
   std::uint32_t m_first_chunk;

--- a/include/shiguredo/mp4/box/stts.hpp
+++ b/include/shiguredo/mp4/box/stts.hpp
@@ -31,7 +31,9 @@ class SttsEntry {
 
   std::uint64_t writeData(bitio::Writer*) const;
   std::uint64_t readData(bitio::Reader*);
+#if __cplusplus >= 202002L
   auto operator<=>(const SttsEntry&) const = default;
+#endif
 
  private:
   std::uint32_t m_sample_count;

--- a/include/shiguredo/mp4/box_header.hpp
+++ b/include/shiguredo/mp4/box_header.hpp
@@ -27,7 +27,9 @@ class BoxHeader {
   void seekToData(std::istream& is);
   void seekToEnd(std::istream& is);
 
+#if __cplusplus >= 202002L
   auto operator<=>(const BoxHeader&) const = default;
+#endif
 
   std::uint64_t getOffset() const;
   std::uint64_t getSize() const;

--- a/include/shiguredo/mp4/box_type.hpp
+++ b/include/shiguredo/mp4/box_type.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <compare>
 #include <cstdint>
 #include <string>
 
@@ -16,6 +17,8 @@ class BoxType {
 
   std::array<std::uint8_t, 4> getData() const;
   auto operator<=>(const BoxType&) const = default;
+  bool operator<(const BoxType&) const;
+  bool operator==(const BoxType&) const;
 
   std::string toString() const;
   bool matchWith(const BoxType& other) const;

--- a/include/shiguredo/mp4/box_type.hpp
+++ b/include/shiguredo/mp4/box_type.hpp
@@ -16,7 +16,9 @@ class BoxType {
   void setData(const std::uint8_t, const std::uint8_t, const std::uint8_t, const std::uint8_t);
 
   std::array<std::uint8_t, 4> getData() const;
+#if __cplusplus >= 202002L
   auto operator<=>(const BoxType&) const = default;
+#endif
   bool operator<(const BoxType&) const;
   bool operator==(const BoxType&) const;
 

--- a/src/box/avc.cpp
+++ b/src/box/avc.cpp
@@ -1,6 +1,5 @@
 #include "shiguredo/mp4/box/avc.hpp"
 
-#include <bits/exception.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>

--- a/src/box/elst.cpp
+++ b/src/box/elst.cpp
@@ -2,7 +2,6 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
-#include <ext/alloc_traits.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/box/ftyp.cpp
+++ b/src/box/ftyp.cpp
@@ -2,7 +2,6 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
-#include <ext/alloc_traits.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/box/pssh.cpp
+++ b/src/box/pssh.cpp
@@ -2,7 +2,6 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
-#include <ext/alloc_traits.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/box/sample_entry.cpp
+++ b/src/box/sample_entry.cpp
@@ -1,6 +1,5 @@
 #include "shiguredo/mp4/box/sample_entry.hpp"
 
-#include <bits/exception.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>

--- a/src/box/styp.cpp
+++ b/src/box/styp.cpp
@@ -2,7 +2,6 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
-#include <ext/alloc_traits.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/box_info.cpp
+++ b/src/box_info.cpp
@@ -1,6 +1,5 @@
 #include "shiguredo/mp4/box_info.hpp"
 
-#include <bits/exception.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>

--- a/src/box_map.cpp
+++ b/src/box_map.cpp
@@ -1,6 +1,5 @@
 #include "shiguredo/mp4/box_map.hpp"
 
-#include <bits/exception.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>

--- a/src/box_type.cpp
+++ b/src/box_type.cpp
@@ -38,6 +38,28 @@ std::array<std::uint8_t, 4> BoxType::getData() const {
   return m_data;
 }
 
+bool BoxType::operator<(const BoxType& r) const {
+  auto r_data = r.getData();
+  for (std::size_t i = 0; i < m_data.size(); i++)
+  {
+    if (m_data[i] < r_data[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool BoxType::operator==(const BoxType& r) const {
+  auto r_data = r.getData();
+  for (std::size_t i = 0; i < m_data.size(); i++)
+  {
+    if (m_data[i] != r_data[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::string BoxType::toString() const {
   if (std::all_of(std::begin(m_data), std::end(m_data),
                   [](const std::uint8_t ch) { return std::isprint(ch) != 0 || ch == 0xa9; })) {

--- a/src/box_type.cpp
+++ b/src/box_type.cpp
@@ -39,25 +39,11 @@ std::array<std::uint8_t, 4> BoxType::getData() const {
 }
 
 bool BoxType::operator<(const BoxType& r) const {
-  auto r_data = r.getData();
-  for (std::size_t i = 0; i < std::size(m_data); i++)
-  {
-    if (m_data[i] < r_data[i]) {
-      return true;
-    }
-  }
-  return false;
+  return m_data < r.getData();
 }
 
 bool BoxType::operator==(const BoxType& r) const {
-  auto r_data = r.getData();
-  for (std::size_t i = 0; i < std::size(m_data); i++)
-  {
-    if (m_data[i] != r_data[i]) {
-      return false;
-    }
-  }
-  return true;
+  return m_data == r.getData();
 }
 
 std::string BoxType::toString() const {

--- a/src/box_type.cpp
+++ b/src/box_type.cpp
@@ -40,7 +40,7 @@ std::array<std::uint8_t, 4> BoxType::getData() const {
 
 bool BoxType::operator<(const BoxType& r) const {
   auto r_data = r.getData();
-  for (std::size_t i = 0; i < m_data.size(); i++)
+  for (std::size_t i = 0; i < std::size(m_data); i++)
   {
     if (m_data[i] < r_data[i]) {
       return true;
@@ -51,7 +51,7 @@ bool BoxType::operator<(const BoxType& r) const {
 
 bool BoxType::operator==(const BoxType& r) const {
   auto r_data = r.getData();
-  for (std::size_t i = 0; i < m_data.size(); i++)
+  for (std::size_t i = 0; i < std::size(m_data); i++)
   {
     if (m_data[i] != r_data[i]) {
       return false;

--- a/src/reader/reader.cpp
+++ b/src/reader/reader.cpp
@@ -1,6 +1,5 @@
 #include "shiguredo/mp4/reader/reader.hpp"
 
-#include <bits/exception.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>


### PR DESCRIPTION
libwebrtc と合わせて使おうとした際に、 chromium 向けのカスタム libc++ を利用するのですが、その場合においてビルドエラーとなってしまう箇所を修正しました。

変更は以下の二点となります。

- 使われていない include の削除
- 宇宙船演算子が暗黙的に削除された際に std::map で必要とされる演算子が不足するため追記 

挙動に変化がないように修正しましたので、受け入れていただけますと幸いです。